### PR TITLE
Fix formatting

### DIFF
--- a/docs/software/conda.md
+++ b/docs/software/conda.md
@@ -97,16 +97,16 @@ conda info
 ```
 
 ```output hl_lines="7"
-     active environment : base
+active environment : base
 
-     ...
+...
 
-       virtual packages : __archspec=1=cascadelake
-                          __conda=24.11.3=0
-                          __cuda=12.4=0
-                          __glibc=2.17=0
-                          __linux=3.10.0=0
-                          __unix=0=0
+virtual packages : __archspec=1=cascadelake
+                   __conda=24.11.3=0
+                   __cuda=12.4=0
+                   __glibc=2.17=0
+                   __linux=3.10.0=0
+                   __unix=0=0
 ```
 
 We can see in the output (highlighted above) that conda detects a virtual CUDA

--- a/docs/software/julia.md
+++ b/docs/software/julia.md
@@ -12,19 +12,25 @@ In order to use Julia in a Jupyter Notebook through OnDemand, you'll first need 
 First, load any of the available Julia modules.
 You can see the available modules using `module avail -i julia` and load the module using `module load julia/<version number here>`.
 Next, load the Julia module, and open a Julia terminal:
+
 ```bash
 module load julia
 julia
 ```
+
 After these commands, you'll see your prompt change to the Julia terminal:
+
 ```bash
 julia>
 ```
+
 Then in the Julia terminal, install the IJulia kernel:
+
 ```julia
 using Pkg
 Pkg.add("IJulia")
 ```
+
 After this, the Julia kernel is installed for you.
 (You'll only need to add the IJulia package once.)
 
@@ -38,7 +44,8 @@ Once your Jupyter session starts, select the Julia kernel:
 
 ## Julia Batch Script Example
 
-Once you've developed and refined your Julia code, you may want to submit it as a batch submission to the scheduler.
+Once you've developed and refined your Julia code, you may want to submit it as
+a batch submission to the scheduler.
 Following is an example of how to do just that.
 
 1. Create your script. The example below is called `hello_world.jl`:
@@ -66,9 +73,9 @@ julia hello_world.jl
 ```
 
 3. Submit to the scheduler
-```bash
-sbatch julia-slurm.sh
-```
+    ```bash
+    sbatch julia-slurm.sh
+    ```
 
 ## Resources
 - [Julia Documentation](https://docs.julialang.org/){:target="_blank"}: Comprehensive guides, tutorials, and references.

--- a/docs/software/moose.md
+++ b/docs/software/moose.md
@@ -7,8 +7,9 @@ MOOSE (Multiphysics Object-Oriented Simulation Environment) is a powerful simula
 We recommend following the [Conda MOOSE Environment](https://mooseframework.inl.gov/getting_started/installation/conda.html){:target="_blank"} instructions provided by INL.
 
 You will need to request an interactive session on a compute node to complete the MOOSE installation. You can do this using
+
 ```bash
-dev-session-bsu
+dev-session
 ```
 
 When you are ready to submit a MOOSE job, here is an example submission script to get you started:

--- a/docs/software/quantumespresso.md
+++ b/docs/software/quantumespresso.md
@@ -9,9 +9,11 @@ structures.
 To download pseudopotentials:
 
     - Visit: [Quantum ESPRESSO Pseudopotentials](
-        https://pseudopotentials.quantum-espresso.org/legacy_tables){:target="_blank"} to get a
+        https://pseudopotentials.quantum-espresso.org/legacy_tables
+        ){:target="_blank"} to get a
     link to download the pseudopotential for your atom(s) of interest.
     - Use `wget` to download the pseudopotential via the command line:
+
         ```bash
         wget [pseudopotential_url]
         ```

--- a/docs/software/r.md
+++ b/docs/software/r.md
@@ -14,75 +14,101 @@ Jupyter notebooks can be used to run R, but first you'll need to create a conda 
         You may want to run the next steps in an interactive session, so your process is not killed on the login node. Use `dev-session` to request an interactive session.
 
 1. Once mamba/conda is installed, we'll use it to create a new environment:
+
     ```bash
     mamba create -n r-env -c conda-forge r-recommended r-irkernel jupyter
     ```
-    In this example, we're creating an environment called `r-env` and pulling the packages `r-recommended`, `r-irkernel`, and `jupyter` from the `conda-forge` channel.
+    In this example, we're creating an environment called `r-env` and pulling
+    the packages `r-recommended`, `r-irkernel`, and `jupyter` from the
+    `conda-forge` channel.
 
     !!! info
-        If you installed a different conda/mamba distribution (e.g., miniconda), you may need to replace `mamba` with `conda`.
+        If you installed a different conda/mamba distribution (e.g.,
+        miniconda), you may need to replace `mamba` with `conda`.
 
-2. After the environment is created, we'll activate it and install the interactive R kernel:
+2. After the environment is created, we'll activate it and install the
+    interactive R kernel:
+
     ```bash
     mamba activate r-env
     R -e 'IRkernel::installspec()'
     ```
 
 And that concludes the installation!
-To use the newly-installed R-kernel, navigate to [ondemand.boisestate.edu](https://ondemand.boisestate.edu){:target="_blank"} and request a Jupyter Notebook session through the Interactive Apps tab.
+To use the newly-installed R-kernel, navigate to
+[ondemand.boisestate.edu](https://ondemand.boisestate.edu){:target="_blank"}
+and request a Jupyter Notebook session through the Interactive Apps tab.
 On the notebook screen, open the dropdown for a "New" notebook and select "R".
 
 ## Installing R packages
 
 There are many R packages beyond the standard library.
-If you find yourself getting an error like `there is no package called ‘PACKAGENAME’`, you probably need to install a package.
+If you find yourself getting an error like `there is no package called
+‘PACKAGENAME’`, you probably need to install a package.
 Here are a couple ways you can install packages in R:
 
 ### Using Conda/Mamba
 Many R packages are hosted on the conda-forge channel using the naming
-convention `r-PACKAGENAME` where `PACKAGENAME` is the name of the R package, e.g., `r-tidyverse`.
+convention `r-PACKAGENAME` where `PACKAGENAME` is the name of the R package,
+e.g., `r-tidyverse`.
 If you want to check if an R package is available via conda or check what
-builds/versions are available, try searching `r-PACKAGENAME` with the name of the package you're looking for) on [anaconda.org](https://anaconda.org){:target="_blank"}.
+builds/versions are available, try searching `r-PACKAGENAME` with the name of
+the package you're looking for) on
+[anaconda.org](https://anaconda.org){:target="_blank"}.
 
 - To install an R package into an existing environment:
+
     ```bash
     mamba activate r-env
     mamba install -c conda-forge r-PACKAGENAME
     ```
-    (See [above](#using-r-in-a-jupyter-notebook) for how to install R in a conda environment.)
+
+    (See [above](#using-r-in-a-jupyter-notebook) for how to install R in a
+    conda environment.)
 
 - To create a new environment containing your R package:
+
     ```bash
     mamba create -n r-env -c conda-forge r-recommended r-PACKAGENAME
     ```
 
 For both methods, you'll need to activate the environment each time before
 calling R:
+
 ```bash
 mamba activate r-env
 ```
 
 ### Using a module
 1. Load an R module:
+
     ```bash
     module load borah-misc r/4.2.2
     ```
+
 2. Start an R terminal and install your desired package:
+
     ```bash
     R
     ```
+
     ```r
     install.packages("PACKAGENAME")
     ```
+
     where `PACKAGENAME` is the name of the package you want to install.
-    It will ask if you want to install into a personal library in your home directory—say yes—and ask you to select a mirror—you can just choose the geographically closest one.
+    It will ask if you want to install into a personal library in your home
+    directory—say yes—and ask you to select a mirror—you can just choose the
+    geographically closest one.
 
 Once the package is finished installing, you're ready to go.
-If you run into issues installing a package, please contact [researchcomputing@boisestate.edu](mailto:researchccomputing@boisestate.edu).
+If you run into issues installing a package, please contact
+[researchcomputing@boisestate.edu](mailto:researchccomputing@boisestate.edu).
 
 ## Submitting an R job to the scheduler
 
-Once you have your R packages installed you're ready to submit a job to the scheduler.
+Once you have your R packages installed you're ready to submit a job to the
+scheduler.
 (More info about [scheduling a job](../scheduling.md).)
 
 Below is an example submission script if you are using R from a module:
@@ -104,11 +130,13 @@ Rscript myscript.R
 ```
 
 This script can be submitted using `sbatch`:
+
 ```bash
 sbatch r-slurm.sh
 ```
 
-If you are using R from a conda environment, just replace lines 9 and 10 in the above script (highlighted) with the following:
+If you are using R from a conda environment, just replace lines 9 and 10 in the
+above script (highlighted) with the following:
 
 ```bash title="r-slurm.sh" linenums="9"
 # Activate your environment

--- a/docs/software/vasp.md
+++ b/docs/software/vasp.md
@@ -48,8 +48,8 @@ scheduler.
 
 3. Submit the Job
 
-    In the dirctory containing your job script and input files submit the job to
-the scheduler:
+    In the dirctory containing your job script and input files submit the job
+    to the scheduler:
 
     ```bash
     sbatch vasp-slurm.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==1.4.0
-mkdocs-material
-Pygments
+mkdocs==1.6.1
+mkdocs-material==9.7.6
+Pygments==2.20.0


### PR DESCRIPTION
A bunch of formatting (mostly code blocks and call-outs) that rendered correctly on my local build appears to be broken on the docs page. I have updated the requirements, and (hopefully) fixed the formatting!